### PR TITLE
Add .github/CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# JavaScript Maintainers team owns every file in this repository.
+* @ion8/javascript-maintainers


### PR DESCRIPTION
Default is for Javascript Maintainers to be responsible for this repository, as well as repositories forked from this one.