### PR TITLE
Change node version to >18

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,5 +29,8 @@
     "eslint-config-next": "^13.2.3",
     "postcss": "^8.4.21",
     "tailwindcss": "^3.2.6"
+  },
+  "engines": {
+    "node": ">=18.x.x"
   }
 }


### PR DESCRIPTION
This PR changes the node version of the app to >18 to comply with Vercel requirements