### PR TITLE
Fix yarn lint command

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
         "codeceptjs": "^3.5.1",
         "eslint": "^8.46.0",
         "eslint-config-next": "^13.4.9",
+        "eslint-config-prettier": "^9.0.0",
         "playwright": "^1.35.1",
         "postcss": "^8.4.25",
         "tailwindcss": "^3.3.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2400,6 +2400,11 @@ eslint-config-next@^13.4.9:
     eslint-plugin-react "^7.31.7"
     eslint-plugin-react-hooks "5.0.0-canary-7118f5dd7-20230705"
 
+eslint-config-prettier@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-9.0.0.tgz#eb25485946dd0c66cd216a46232dc05451518d1f"
+  integrity sha512-IcJsTkJae2S35pRsRAwoCE+925rJJStOdkKnLVgtE+tEpqU0EVVM7OqrwxqgptKdX29NUwC82I5pXsGFIgSevw==
+
 eslint-import-resolver-node@^0.3.6, eslint-import-resolver-node@^0.3.7:
   version "0.3.7"
   resolved "https://registry.yarnpkg.com/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.7.tgz#83b375187d412324a1963d84fa664377a23eb4d7"


### PR DESCRIPTION
The configuration in `.eslintrc.json` was:
```
{
  "extends": ["next", "next/core-web-vitals", "prettier"],
  "rules": {
    "react/no-unescaped-entities": "off"
  }
}
```

This requires the package `eslint-config-prettier`, but this was not installed.

This PR adds eslint-config-prettier as a dev dependency.

Before:
![image](https://github.com/ion8/nextjs-starter/assets/2661404/4b18e242-bc1f-4990-802a-24040a003a5d)

After:
![image](https://github.com/ion8/nextjs-starter/assets/2661404/8e6fc171-416a-45dd-885e-93c3541281ea)
