### PR TITLE
Backporting forms

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "codeceptjs:headless": "HEADLESS=true codeceptjs run --steps"
   },
   "dependencies": {
+    "@hookform/error-message": "^2.0.1",
     "@hookform/resolvers": "^3.3.2",
     "@next/codemod": "^14.0.2",
     "axios": "^1.6.2",

--- a/src/components/layout/index.js
+++ b/src/components/layout/index.js
@@ -1,7 +1,12 @@
+import { useContext, useEffect } from 'react';
+
+import { ContactFormContext } from '@/utils/context';
 import Footer from '@/components/layout/footer';
+import { FormModal } from '@/ui/modals';
 import Main from '@/components/layout/main';
 import Navbar from '@/components/layout/navbar';
 import SEO from '@/components/layout/seo';
+import { useRouter } from 'next/router';
 
 // conversionPageUrl tracks the path that leads to contact form
 const Layout = ({
@@ -12,8 +17,32 @@ const Layout = ({
   conversionPageUrl,
   children,
 }) => {
+  const router = useRouter();
+  const { contactFormOpen, setContactFormOpen } = useContext(ContactFormContext);
+
+  /*
+    The following lines make sure that we have a URL that directly opens the form modal. 
+    Use case: http://ion8.net/?showForm=true - this url can be used in an email notification, and when clicked it will redirect users to the website and directly to the form modal opened.
+  */
+  useEffect(() => {
+    if (router.isReady) {
+      const { showForm } = router.query;
+      if (showForm && showForm === 'true') {
+        setContactFormOpen(true);
+      } else {
+        setContactFormOpen(false);
+      }
+    }
+  }, [router.query, router.isReady]);
+
   return (
     <>
+      {contactFormOpen ? (
+        <FormModal
+          pageTitle={seoTitle}
+          setShowForm={contactFormOpen}
+        />
+      ) : null}
       <SEO
         title={seoTitle}
         description={seoDesc}

--- a/src/components/layout/navbar.js
+++ b/src/components/layout/navbar.js
@@ -1,8 +1,8 @@
+import { Button, FormPopupBtn } from '@/ui/buttons';
 import { CloseIcon, HamburgerIcon } from '@/svgs/icons';
 import { H3, LgText, NavbarLink } from '@/ui/typography';
 import { useEffect, useState } from 'react';
 
-import { Button } from '@/ui/buttons';
 import { Container } from '@/ui/containers';
 import Link from 'next/link';
 
@@ -40,6 +40,10 @@ const Navbar = ({ conversionPageUrl }) => {
           name: 'accordions',
           href: '/components-gallery/list-of-accordions',
         },
+        {
+          name: 'forms',
+          href: '/components-gallery/list-of-forms',
+        },
       ],
     },
   ];
@@ -56,6 +60,7 @@ const Navbar = ({ conversionPageUrl }) => {
     <nav>
       <Container className='justify-between h-[72px] md:h-[94px] flex'>
         <div className='flex items-center flex-grow py-3 md:flex-none'>
+          {/* Logo here */}
           <Link
             href='/'
             className='font-bold text-cobalt'>
@@ -108,11 +113,9 @@ const Navbar = ({ conversionPageUrl }) => {
           )}
         </div>
         <div className='hidden md:block'>
-          <Button
-            link={'/contact-us' + '?conversionPageUrl=' + conversionPageUrl}
-            label='Contact Us'
-            variant='primary'
-            type='link'
+          <FormPopupBtn
+            className='h-12 w-[200px] hidden md:flex'
+            label='Contact us'
           />
         </div>
 
@@ -179,12 +182,12 @@ const Navbar = ({ conversionPageUrl }) => {
             )}{' '}
           </ul>{' '}
           {/* end of navigation.map ? */}
-          <div className='mt-5 md:hidden'>
-            <Button
-              link={'/contact-us' + '?conversionPageUrl=' + conversionPageUrl}
-              label='Contact Us'
-              variant='primary'
-              type='link'
+          <div
+            id='mobileBtn'
+            className='mt-5 md:hidden mx-auto'>
+            <FormPopupBtn
+              className='h-12 w-full md:hidden flex'
+              label='Contact us'
             />
           </div>
         </div>

--- a/src/components/ui/buttons.js
+++ b/src/components/ui/buttons.js
@@ -1,5 +1,28 @@
 import { BodyText } from '@/ui/typography';
 import Link from 'next/link';
+import { useRouter } from 'next/router';
+
+export const FormPopupBtn = ({ label, className, ...props }) => {
+  const router = useRouter();
+  const handleRoute = () => {
+    // Preserve existing query parameters and add showForm parameter
+    const newQuery = { ...router.query, showForm: true };
+    router.push({ pathname: router.pathname, query: newQuery }, undefined, {
+      shallow: true,
+    });
+  };
+  return (
+    <button
+      className={
+        `flex justify-center items-center py-[10px] rounded-[5px] text-white bg-cyan px-9 focus:outline-none focus:ring-none hover:bg-cobalt ` +
+        className
+      }
+      onClick={handleRoute}
+      {...props}>
+      {label ? <span>{label}</span> : <span>Request a quote</span>}
+    </button>
+  );
+};
 
 /**
  * @description - this component is particular to the footer section links
@@ -19,10 +42,9 @@ export const FooterLink = ({ link, conversionPageUrl, label, className = '' }) =
 };
 
 /**
- * @description - this is the primary button based on Figma styleguide definition
+ * @description - Submit or link button based on Figma styleguide definition
  * @param {url} link - url to the destination
  * @param {string} label - text to be displayed
-
  * @param {string} variant - possible values are primary or secondary and if not exists then it will be default(tertiary) based on Figma
  * @param {boolean} hasIcon - if an icon exists
  * @param {string} type - possible values are button or link
@@ -51,7 +73,9 @@ export const Button = ({
               ? 'text-white bg-cobalt hover:bg-cyan'
               : variant == 'secondary'
                 ? 'text-white bg-cyan hover:bg-cobalt'
-                : 'text-black bg-cool-grey hover:bg-cyan'
+                : variant == 'tertiary'
+                  ? 'text-black bg-cyan hover:bg-deep-blue'
+                  : null
           }`}>
           <span className={`mr-[10px] ml-0 ${!hasIcon ? 'hidden' : ''}`}>
             {children}
@@ -61,14 +85,19 @@ export const Button = ({
       ) : type == 'button' ? (
         // for a submit button
         <button
-          className={` inline-block w-full md:w-auto py-4 justify-center items-center rounded-[5px] px-5 focus:outline-none focus:ring-none font-bold mt-10 ${
+          className={` inline-block w-full md:w-auto py-4 justify-center items-center rounded-[5px] px-20 focus:outline-none focus:ring-none font-bold ${
             variant == 'primary'
               ? 'text-white bg-cobalt hover:bg-cyan'
               : variant == 'secondary'
                 ? 'text-white bg-cyan hover:bg-cobalt'
-                : 'text-black bg-cool-grey hover:bg-cyan'
+                : variant == 'tertiary'
+                  ? 'text-black bg-cyan hover:bg-light-blue'
+                  : null
           }`}
           type='submit'>
+          <span className={`mr-[10px] ml-0 ${!hasIcon ? 'hidden' : ''}`}>
+            {children}
+          </span>
           <span>{label}</span>
         </button>
       ) : null}
@@ -77,16 +106,21 @@ export const Button = ({
 };
 
 /**
- * @description - the submit button for a form
- * @param {*} param0
+ * @description - This button is used as a next/back button for the two-step-form.js
+ * @param {string} label - label of the button
+ * @param {string} className - extra TailwindCSS classes if needed
+ * @param {*} props - the onClick event handler
  * @returns
  */
-export const SubmitButton = ({ label, children, className = '', ...props }) => {
+export const ButtonNoLink = ({ label, className, ...props }) => {
   return (
-    <button
-      className={`block py-3 text-center text-white rounded-lg bg-cobalt md:inline-block hover:bg-cyan focus:outline-none focus:ring ${className}`}
-      type='submit'>
-      <span>{label}</span>
-    </button>
+    <div
+      className={
+        'inline-block py-[14px] justify-center items-center text-white rounded-[8px] px-6 focus:outline-none focus:ring-none bg-cyan hover:bg-teal disabled:bg-[#d1d5db] cursor-pointer ' +
+        className
+      }
+      {...props}>
+      <span className='text-base font-normal'>{label}</span>
+    </div>
   );
 };

--- a/src/components/ui/form-elements.js
+++ b/src/components/ui/form-elements.js
@@ -2,28 +2,51 @@ import { Checkbox, Radio } from 'flowbite-react';
 import { SmText, XsText } from '@/ui/typography';
 import { useFieldArray, useForm } from 'react-hook-form';
 
+import { useState } from 'react';
+
+/**
+ *
+ * @component - A Label called from within the field
+ *
+ * @param {string} label - label of the field
+ * @param {string} name - name of the field used in htmlFor attribute to connect the label to the field that's used for
+ * @param {boolean} isRequired - indicates whether a required field indicator such as an asterisk should be displayed or not
+ * @param {string} className - extra TailwindCSS classes if needed eg. className='text-black mt-10 text-right'
+ * @returns {JSX.Element} - a Label component for labeling fields
+ * @example - <Label label={label} name={name} isRequired={isRequired} />
+ */
 export const Label = ({ label, name, isRequired, className }) => {
   return (
     <label htmlFor={name}>
       <SmText className={`font-medium ${className}`}>
-        {label} {isRequired ? <span className={'inline text-red-600'}>*</span> : <></>}
+        {label} {isRequired ? <span className={'inline text-red-600'}>*</span> : null}
       </SmText>
     </label>
   );
 };
 
+/**
+ * @component - input field eg text, number, password or email
+ *
+ * @param {string} label - label of the field
+ * @param {string} name - name of the field
+ * @param {type} type - type of the field - possible values: text, number, password, email
+ * @param {string} placeholder - text that would be displayed as the placeholder
+ * @param {*} register - registers the field for Yup validation
+ * @param {string} errorMessage - the error message that would be displayed if the field is required and fails the validation
+ * @param {boolean} isRequired - just for UI purposes; if exists then it will be passed on to the Label component in order to display the asterisk
+ * @param {string} className - extra TailwindCSS classes if needed eg. className='text-black mt-10 text-right'
+ * @returns {JSX.Element} - an Input component for capturing input from the user
+ */
 export const Input = ({
   label,
   name,
-  id,
   type,
   placeholder,
   register,
   errorMessage,
   isRequired,
   className,
-  children,
-  ...props
 }) => {
   return (
     <>
@@ -33,13 +56,12 @@ export const Input = ({
         isRequired={isRequired}
       />
 
-      {/* #ToDo - invalid:border-red-500 invalid:text-red-500 */}
       <input
         className={
-          'px-4 py-3 text-sm font-inter font-normal rounded-lg bg-gray-50 border border-solid border-gray-300 w-full focus:border-gray-900 focus:ring-transparent focus:outline-none mt-2 ' +
+          `${errorMessage ? 'border-red-500 text-red-500 ' : null}
+          px-4 py-3 text-sm font-inter font-normal rounded-lg bg-gray-50 border border-solid border-gray-300 w-full focus:border-gray-900 focus:ring-transparent focus:outline-none mt-2 ` +
           className
         }
-        id={name}
         name={name}
         type={type}
         placeholder={placeholder}
@@ -52,17 +74,27 @@ export const Input = ({
   );
 };
 
+/**
+ * @component - textarea field for multiline user inputs usually messages or details
+ *
+ * @param {string} label - label of the field
+ * @param {name} name - name of the field
+ * @param {string} placeholder - text that would be displayed as the placeholder
+ * @param {*} register - registers the field for Yup validation
+ * @param {string} errorMessage - the error message that would be displayed if the field is required and fails the validation
+ * @param {boolean} isRequired - just for UI purposes; if exists then it will be passed on to the Label component in order to display the asterisk
+ * @param {string} className - extra TailwindCSS classes if needed eg. className='text-black mt-10 text-right'
+ * @returns {JSX.Element} - a Textarea component
+ */
+
 export const Textarea = ({
   label,
   name,
-  id,
   placeholder,
   register,
   errorMessage,
   isRequired,
   className,
-  children,
-  ...props
 }) => {
   return (
     <>
@@ -74,11 +106,12 @@ export const Textarea = ({
 
       <textarea
         className={
-          'px-4 py-3 rounded-lg text-sm font-normal bg-gray-50 h-28 border border-solid border-gray-300 w-full focus:border-gray-900 focus:ring-transparent focus:outline-none mt-2 ' +
+          `${
+            errorMessage ? 'border-red-500 text-red-500 ' : null
+          } px-4 py-3 rounded-lg text-sm font-normal bg-gray-50 h-28 border border-solid border-gray-300 w-full focus:border-gray-900 focus:ring-transparent focus:outline-none mt-2 ` +
           className
         }
         name={name}
-        id={id}
         placeholder={placeholder}
         {...register}
       />
@@ -89,22 +122,38 @@ export const Textarea = ({
   );
 };
 
+/**
+ * @component - a dropdown / select field
+ *
+ * @param {string} label - label of the field
+ * @param {name} name - name of the field
+ * @param {array} options - an array of values to fill in the select field as options
+ * @param {event} onChange - if exists then it will replace the default handler with a custom one eg. if we have conditional fields. See form-with-conditional-fields.js
+ * @param {string} value - the selected value
+ * @param {*} register - registers the field for Yup validation
+ * @param {string} errorMessage - the error message that would be displayed if the field is required and fails the validation
+ * @param {boolean} isRequired - just for UI purposes; if exists then it will be passed on to the Label component in order to display the asterisk
+ * @param {string} className - extra TailwindCSS classes if needed eg. className='text-black mt-10 text-right'
+ * @returns {JSX.Element} - a select component
+ */
+
 export const Select = ({
   label,
   name,
   options,
+  onChange,
+  value,
   register,
   isRequired,
   errorMessage,
   className,
-  children,
-  ...props
 }) => {
   const { setValue, control } = useForm();
 
   const handleSelectChange = value => {
     setValue(name, value);
   };
+
   return (
     <>
       <Label
@@ -116,11 +165,14 @@ export const Select = ({
       <select
         name={name}
         className={
-          'w-full px-4 py-3 text-sm font-inter font-normal rounded-lg bg-gray-50 border border-solid border-gray-300 focus:border-cyan focus:outline-none mt-2 ' +
+          `${
+            errorMessage ? 'border-red-500 text-red-500 ' : null
+          } w-full px-4 py-3 text-sm font-inter font-normal rounded-lg bg-gray-50 border border-solid border-gray-300 focus:border-cyan focus:outline-none mt-2 ` +
           className
         }
-        onChange={e => handleSelectChange(e.target.value)}
-        {...register}>
+        {...register}
+        onChange={onChange ? onChange : e => handleSelectChange(e.target.value)}
+        value={value}>
         <option value=''>Select an option</option>
         {options.map((option, index) => (
           <option
@@ -138,10 +190,26 @@ export const Select = ({
   );
 };
 
+// todo: The checkbox if required, doesn't display the error message, which in fact should. This needs to be revisited.
+
+/**
+ * @component - a checkbox list
+ *
+ * @param {string} label - label of the field
+ * @param {name} name - name of the field
+ * @param {array} options - an array of values to fill in the checkboxes list field as options
+ * @param {event} onChange - if exists then it will replace the default handler with a custom one eg. if we have conditional fields. See form-with-conditional-fields.js
+ * @param {*} register - registers the field for Yup validation
+ * @param {string} errorMessage - the error message that would be displayed if the field is required and fails the validation
+ * @param {boolean} isRequired - just for UI purposes; if exists then it will be passed on to the Label component in order to display the asterisk
+ * @param {string} className - extra TailwindCSS classes if needed eg. className='text-black mt-10 text-right'
+ * @returns {JSX.Element} - a checkbox list component
+ */
 export const CheckboxList = ({
   label,
   name,
   options,
+  onChange,
   register,
   isRequired,
   errorMessage,
@@ -167,7 +235,7 @@ export const CheckboxList = ({
         className='block text-gray-900'
       />
 
-      <div className={`grid grid-flow-col mt-4`}>
+      <div className={`grid grid-flow-row lg:grid-flow-col mt-4`}>
         {options.map((option, index) => (
           <div key={index}>
             <Checkbox
@@ -175,7 +243,7 @@ export const CheckboxList = ({
               value={option}
               className='focus:ring-2 focus:ring-green-500 text-green-500 w-4 h-4 p-2.5 bg-gray-50 rounded border border-gray-300'
               {...register}
-              onChange={() => handleCheckboxChange(index)}
+              onChange={onChange ? onChange : () => handleCheckboxChange(index)}
             />{' '}
             <Label
               name={name + index}
@@ -192,10 +260,26 @@ export const CheckboxList = ({
   );
 };
 
+// todo: The radio buttons list by default should display the validation/error message if the user misses to select any and tries to submit the form. Currently, the error message is not displayed.
+
+/**
+ * @component - a radio buttons list
+ *
+ * @param {string} label - label of the field
+ * @param {name} name - name of the field
+ * @param {array} options - an array of values to fill in the radio buttons list as options
+ * @param {event} onChange - if exists then it will replace the default handler with a custom one eg. if we have conditional fields. See form-with-conditional-fields.js
+ * @param {*} register - registers the field for Yup validation
+ * @param {string} errorMessage - the error message that would be displayed if the field is required and fails the validation
+ * @param {boolean} isRequired - just for UI purposes; if exists then it will be passed on to the Label component in order to display the asterisk
+ * @param {string} className - extra TailwindCSS classes if needed eg. className='text-black mt-10 text-right'
+ * @returns {JSX.Element} - a radio buttons list component
+ */
 export const RadioButtonList = ({
   label,
   name,
   options,
+  onChange,
   register,
   isRequired,
   errorMessage,
@@ -218,16 +302,15 @@ export const RadioButtonList = ({
         className='block text-gray-900'
       />
 
-      <div className={`grid grid-flow-col mt-4`}>
+      <div className={`grid grid-flow-row lg:grid-flow-col mt-4`}>
         {options.map((option, index) => (
           <div key={index}>
             <Radio
               name={name[index]}
               value={option}
-              // type='radio'
               className='w-4 h-4 border border-gray-300 focus:ring-2 focus:ring-green-500 text-gray-50 bg-gray-50 rounded-3xl checked:border-green-500 checked:rounded-full checked:border-4 focus:border-green-500 focus:rounded-full focus:border-4'
               {...register}
-              onChange={() => handleRadioChange(index)}
+              onChange={onChange ? onChange : () => handleRadioChange(index)}
             />{' '}
             <Label
               name={name + index}

--- a/src/components/ui/forms/form-with-conditional-fields.js
+++ b/src/components/ui/forms/form-with-conditional-fields.js
@@ -1,0 +1,115 @@
+import * as Yup from 'yup';
+
+import { Input, RadioButtonList, Select } from '@/ui/form-elements';
+
+import { Button } from '@/ui/buttons';
+import { XsText } from '@/ui/typography';
+import axios from 'axios';
+import { useForm } from 'react-hook-form';
+import { useRouter } from 'next/router';
+import { useState } from 'react';
+import { yupResolver } from '@hookform/resolvers/yup';
+
+export const FormWConditionalFields = ({ conversionPageUrl }) => {
+  /* for the conditional field for the radio list and the dropdown */
+  const [ageGroupSelection, setAgeGroupSelection] = useState('');
+
+  // display the message based on value selected
+  const [selectedOption, setSelectedOption] = useState('Select an option');
+  const displayConditionalField = event => {
+    setSelectedOption(event.target.value);
+  };
+
+  const router = useRouter();
+  const [isSubmitted, setIsSubmitted] = useState(false);
+  const [loading, setLoading] = useState(false);
+
+  const validationSchema = Yup.object().shape({
+    aboutYourDepartment: Yup.string().required('Please select one of the options'),
+    deptDetails: Yup.string(),
+    // #todo: The following lines requires a revisit since it doesn't work as expected.
+    // The requirement is that when the 'Software Engineering' is selected from the select, only then the deptDetails is required and should display the validation message otherwise deptDetails is optional.
+
+    // deptDetails: Yup.string().when('aboutYourDepartment', {
+    //   is: 'Software Engineering',
+    //   then: Yup.string().required('Please write something about your department'),
+    // }),
+    ageGroupLst: Yup.string(),
+  });
+
+  const { formState, register, handleSubmit } = useForm({
+    resolver: yupResolver(validationSchema),
+  });
+  const { errors } = formState;
+
+  const onSubmit = data => {
+    // The following console.log code is for debugging purposes to make sure all the data is captured. It should be removed on a real project.
+    // console.log(data);
+    // add the submit code for webhook and axios call here - you can find the sample code in the general-form.js
+  };
+  return (
+    <div className='justify-center py-20 md:text-left'>
+      <form
+        id='form'
+        className=''
+        onSubmit={handleSubmit(onSubmit)}>
+        <div className='grid grid-cols-1 gap-10 md:grid-cols-2'>
+          {/* Dropdown Field - Required */}
+          <div className=''>
+            <Select
+              label='Tell us about your department'
+              name='aboutYourDepartment'
+              isRequired
+              options={['Software Engineering', 'Sales & Marketing', 'Design']}
+              register={{
+                ...register('aboutYourDepartment'),
+              }}
+              onChange={displayConditionalField}
+              value={selectedOption}
+              errorMessage={errors.aboutYourDepartment?.message}
+            />
+          </div>
+          <div>
+            {/* conditional field that's bound to the aboutYourDepartment dropdown.  */}
+            {selectedOption === 'Software Engineering' ? (
+              <Input
+                label='Tell us something about your department'
+                name='deptDetails'
+                type='text'
+                placeholder='Write something about your department'
+                register={{ ...register('deptDetails', { required: false }) }}
+              />
+            ) : null}
+          </div>
+
+          {/* Radio buttons list */}
+          <div className=''>
+            <RadioButtonList
+              label='What is your age group'
+              name='ageGroupLst'
+              options={['2 - 12', '13 - 30', '31 - 45']}
+              register={{ ...register('ageGroupLst') }}
+              onChange={e => setAgeGroupSelection(e.target.value)}
+            />
+            {/* conditional field that's bound to the ageGroupLst radio buttons.  */}
+            {ageGroupSelection === '2 - 12' ? (
+              <XsText className='mt-2'>You have a free ticket!</XsText>
+            ) : ageGroupSelection === '13 - 30' || ageGroupSelection === '31 - 45' ? (
+              <XsText className='mt-2'>You have 10% discount!</XsText>
+            ) : null}
+          </div>
+
+          {/* Submit Button */}
+          <div className='flex mt-5 md:col-span-2 md:justify-start'>
+            <Button
+              className='px-10'
+              label={loading ? 'Submitting...' : 'Submit'}
+              variant='primary'
+              type='button'
+            />
+          </div>
+        </div>
+      </form>
+    </div>
+  );
+};

--- a/src/components/ui/forms/form-with-dynamic-fields.js
+++ b/src/components/ui/forms/form-with-dynamic-fields.js
@@ -1,0 +1,121 @@
+import * as Yup from 'yup';
+
+import {
+  CheckboxList,
+  Input,
+  RadioButtonList,
+  Select,
+  Textarea,
+} from '@/ui/form-elements';
+import { FormProvider, useForm } from 'react-hook-form';
+
+import { Button } from '@/ui/buttons';
+import { ErrorMessage } from '@hookform/error-message';
+import axios from 'axios';
+import { useRouter } from 'next/router';
+import { useState } from 'react';
+import { yupResolver } from '@hookform/resolvers/yup';
+
+export const Field = ({
+  label,
+  type,
+  name,
+  required,
+  validationMsg,
+  options,
+  className,
+  register,
+  errors,
+}) => {
+  // displays the name of each field
+  console.log('errorMessage: ' + errors);
+  return (
+    <div>
+      {type === 'select' ? (
+        <Select
+          label={label}
+          name={name}
+          isRequired={required}
+          options={options}
+          register={register}
+        />
+      ) : (
+        <Input
+          label={label}
+          name={name}
+          type={type}
+          placeholder={label}
+          isRequired={required}
+          register={register}
+        />
+      )}
+      <ErrorMessage
+        errors={errors}
+        name={name}
+        render={({ message }) => <div>{validationMsg}</div>}
+      />
+    </div>
+  );
+};
+
+export const FormWDynamicFields = ({ fields }) => {
+  const router = useRouter();
+  const [isSubmitted, setIsSubmitted] = useState(false);
+  const [loading, setLoading] = useState(false);
+
+  const validationSchema = Yup.object().shape({
+    firstName: Yup.string().required(),
+    lastName: Yup.string().required(),
+    emailAddress: Yup.string().required(),
+    phoneNumber: Yup.string(),
+    yourDepartment: Yup.array().required(),
+  });
+
+  const {
+    formState: { errors },
+    register,
+    handleSubmit,
+  } = useForm({
+    resolver: yupResolver(validationSchema),
+  });
+
+  const onSubmit = data => {
+    console.log(data);
+  };
+  return (
+    <div className='justify-center pt-20 lg:text-left'>
+      <FormProvider>
+        <form
+          id='form'
+          className=''
+          onSubmit={handleSubmit(onSubmit)}>
+          <div className='grid grid-cols-1 gap-10 md:grid-cols-2'>
+            {fields.map((field, index) => (
+              <Field
+                key={index}
+                name={field.name}
+                label={field.label}
+                type={field.type}
+                required={field.required}
+                validationMsg={field.validationMsg}
+                options={field.options}
+                className={field.className}
+                register={register}
+                errors={errors}
+              />
+            ))}
+            {/* Submit Button */}
+            <div className='flex md:col-span-2 md:justify-end'>
+              <Button
+                className='px-10'
+                label={loading ? 'Submitting...' : 'Submit'}
+                variant='primary'
+                type='button'
+              />
+            </div>
+          </div>
+        </form>
+      </FormProvider>
+    </div>
+  );
+};

--- a/src/components/ui/forms/form-with-dynamic-fields.js
+++ b/src/components/ui/forms/form-with-dynamic-fields.js
@@ -16,48 +16,21 @@ import { useRouter } from 'next/router';
 import { useState } from 'react';
 import { yupResolver } from '@hookform/resolvers/yup';
 
-export const Field = ({
-  label,
-  type,
-  name,
-  required,
-  validationMsg,
-  options,
-  className,
-  register,
-  errors,
-}) => {
-  // displays the name of each field
-  console.log('errorMessage: ' + errors);
-  return (
-    <div>
-      {type === 'select' ? (
-        <Select
-          label={label}
-          name={name}
-          isRequired={required}
-          options={options}
-          register={register}
-        />
-      ) : (
-        <Input
-          label={label}
-          name={name}
-          type={type}
-          placeholder={label}
-          isRequired={required}
-          register={register}
-        />
-      )}
-      <ErrorMessage
-        errors={errors}
-        name={name}
-        render={({ message }) => <div>{validationMsg}</div>}
-      />
-    </div>
-  );
-};
-
+/**
+ * Renders a form with dynamic fields based on the provided fields array.
+ *
+ * @param {Object} props - The component props.
+ * @param {Array} props.fields - An array of objects representing the fields to be rendered in the form.
+ *   Each object should have the following properties:
+ *   - name (string): The name of the field.
+ *   - label (string): The label of the field.
+ *   - type (string): The type of the field.
+ *   - required (boolean): Indicates if the field is required.
+ *   - validationMsg (string): The validation message to display if the field is invalid.
+ *   - options (Array): An array of options for the field (only applicable to select fields).
+ *   - className (string): The CSS class name for the field.
+ * @return {JSX.Element} The rendered form component.
+ */
 export const FormWDynamicFields = ({ fields }) => {
   const router = useRouter();
   const [isSubmitted, setIsSubmitted] = useState(false);
@@ -116,6 +89,61 @@ export const FormWDynamicFields = ({ fields }) => {
           </div>
         </form>
       </FormProvider>
+    </div>
+  );
+};
+
+/**
+ * Renders a form field component based on the provided props.
+ *
+ * @param {Object} props - The component props.
+ * @param {string} props.label - The label of the field.
+ * @param {string} props.type - The type of the field.
+ * @param {string} props.name - The name of the field.
+ * @param {boolean} props.required - Indicates if the field is required.
+ * @param {string} props.validationMsg - The validation message to display if the field is invalid.
+ * @param {Array} props.options - An array of options for the field (only applicable to select fields).
+ * @param {string} props.className - The CSS class name for the field.
+ * @param {function} register - The register function for form validation.
+ * @param {object} errors - The errors object for form validation.
+ * @return {JSX.Element} The rendered form field component.
+ */
+export const Field = ({
+  label,
+  type,
+  name,
+  required,
+  validationMsg,
+  options,
+  className,
+  register,
+  errors,
+}) => {
+  return (
+    <div>
+      {type === 'select' ? (
+        <Select
+          label={label}
+          name={name}
+          isRequired={required}
+          options={options}
+          register={register}
+        />
+      ) : (
+        <Input
+          label={label}
+          name={name}
+          type={type}
+          placeholder={label}
+          isRequired={required}
+          register={register}
+        />
+      )}
+      <ErrorMessage
+        errors={errors}
+        name={name}
+        render={({ message }) => <div>{validationMsg}</div>}
+      />
     </div>
   );
 };

--- a/src/components/ui/forms/general-form.js
+++ b/src/components/ui/forms/general-form.js
@@ -1,26 +1,30 @@
 import * as Yup from 'yup';
 
-import { CheckboxList,RadioButtonList, Input, Select, Textarea } from '@/ui/form-elements';
+import {
+  CheckboxList,
+  Input,
+  RadioButtonList,
+  Select,
+  Textarea,
+} from '@/ui/form-elements';
 
-import { useForm } from 'react-hook-form';
-
-import { SubmitButton } from '@/ui/buttons';
+import { Button } from '@/ui/buttons';
 import axios from 'axios';
+import { useForm } from 'react-hook-form';
 import { useRouter } from 'next/router';
 import { useState } from 'react';
 import { yupResolver } from '@hookform/resolvers/yup';
 
-export const Form = ({ conversionPageUrl }) => {
+export const GeneralForm = ({ conversionPageUrl }) => {
   const router = useRouter();
   const [isSubmitted, setIsSubmitted] = useState(false);
   const [loading, setLoading] = useState(false);
 
   const validationSchema = Yup.object().shape({
     firstName: Yup.string().required('Please enter your first name'),
-    lastName: Yup.string().required('Please enter your last name'),
     emailAddress: Yup.string().required('Please enter your email address'),
     phoneNumber: Yup.string(),
-    aboutYourDepartment: Yup.string().required('Please select one of the options'),
+    aboutYourDepartment: Yup.string().required('Please select your department'),
     hobbiesChk: Yup.array(),
     ageGroupLst: Yup.string(),
     message: Yup.string().required('Please enter your message'),
@@ -32,17 +36,51 @@ export const Form = ({ conversionPageUrl }) => {
   const { errors } = formState;
 
   const onSubmit = data => {
-    //console.log(data);
+    // the following console.log will print out all the data for debugging purposes.
+    console.log(data);
+
+    // The following form submission code is a sample code that can be used and customized for real projects
+    /*
+    const submitURL = `/api/form-handler`;
+    if (data) {
+      const webhookData = {
+        firstName: data.firstName,
+        lastName: data.lastName,
+        phone: data.phoneNumber,
+        email: data.emailAddress,
+        aboutYourDepartment: data.aboutYourDepartment,
+        hobbiesChk: data.hobbiesChk,
+        ageGroupLst: data.ageGroupLst,
+        message: data.message,
+        page: router.pathname,
+        pageTitle: { pageTitle },
+      };
+
     router.push('/thank-you' + conversionPageUrl);
 
+    axios
+        .post(submitURL, webhookData)
+        .then((res) => {
+          setContactFormOpen(false);
+          if (router.pathname.includes('/lp')) {
+            router.push(router.pathname + '/thank-you');
+          } else {
+            router.push('/thank-you');
+          }
+        })
+        .catch((err) => {
+          alert('There was an error submitting your form. Please try again.');
+        });
+    }
+    */
   };
   return (
-    <div className='justify-center py-20 lg:text-left'>
+    <div className='justify-center pt-20 lg:text-left'>
       <form
         id='form'
         className=''
         onSubmit={handleSubmit(onSubmit)}>
-        <div className='grid grid-cols-1 gap-10 lg:grid-cols-2'>
+        <div className='grid grid-cols-1 gap-10 md:grid-cols-2'>
           {/* First name - Required */}
           <div>
             <Input
@@ -52,38 +90,26 @@ export const Form = ({ conversionPageUrl }) => {
               type='text'
               placeholder='First name'
               isRequired
-              register={...register('firstName')}
+              register={{ ...register('firstName') }}
               errorMessage={errors.firstName?.message}
             />
           </div>
 
-          {/* Last name - Required */}
+          {/* Phone number - not required */}
           <div>
-            <Input
-              label='Last name'
-              name='lastName'
-              id='lastName'
-              type='text'
-              placeholder='Last name'
-              isRequired
-              register={ ...register('lastName') }
-              errorMessage={errors.lastName?.message}
-            />
-          </div>
-
-            {/* Phone number - Optional */}
-            <div> 
             <Input
               label='Phone number'
               name='phoneNumber'
               id='phoneNumber'
               type='tel'
               placeholder='Phone number'
-              register={...register('phoneNumber', {
-                required: false,
-              })}
+              register={{
+                ...register('phoneNumber', {
+                  required: false,
+                }),
+              }}
             />
-          </div> 
+          </div>
           {/* Email address - Required */}
           <div>
             <Input
@@ -93,64 +119,56 @@ export const Form = ({ conversionPageUrl }) => {
               type='email'
               placeholder='Email address'
               isRequired
-              register={...register('emailAddress')}
+              register={{ ...register('emailAddress') }}
               errorMessage={errors.emailAddress?.message}
             />
           </div>
-          
-        
 
           {/* Dropdown Field - Required */}
-          <div className='w-1/2 col-span-2'> 
+          <div>
             <Select
-              label='Tell us about your department'
+              label='Which department do you belong to?'
               name='aboutYourDepartment'
               isRequired
               options={['Software Engineering', 'Sales & Marketing', 'Design']}
-              register={...register('aboutYourDepartment')}
+              register={{ ...register('aboutYourDepartment') }}
               errorMessage={errors.aboutYourDepartment?.message}
-              
             />
           </div>
 
-          {/* Optional Checkbox list */}
-          <div className='w-1/2 col-span-2'> 
-          
-          <CheckboxList
+          {/* Checkbox list - not Required */}
+          <div>
+            <CheckboxList
               label='What are your hobbies'
               name='hobbiesChk'
-              isRequired
               options={['Books', 'Biking', 'Gardening']}
-              register={...register('hobbiesChk')}
-            />
-         </div>
-          {/* Optional Checkbox list */}
-          <div className='w-1/2 col-span-2'> 
-          <RadioButtonList
-              label='What is your age group'
-              name='ageGroupLst'
-              options={['2 - 12', '13 - 30', '31 - 45','46 - 65']}
-              register={...register('ageGroupLst')}
+              register={{
+                ...register('hobbiesChk', {
+                  required: false,
+                }),
+              }}
             />
           </div>
 
           {/* Textarea Field - Required */}
-          <div className='col-span-2'>
+          <div>
             <Textarea
               label='Your message'
               name='message'
               id='message'
               isRequired
-              register={...register('message')}
+              register={{ ...register('message') }}
               errorMessage={errors.message?.message}
             />
           </div>
 
           {/* Submit Button */}
-          <div className='flex mt-5 lg:col-span-2 md:justify-end'>
-            <SubmitButton
+          <div className='flex md:col-span-2 md:justify-end'>
+            <Button
               className='px-10'
               label={loading ? 'Submitting...' : 'Submit'}
+              variant='primary'
+              type='button'
             />
           </div>
         </div>

--- a/src/components/ui/forms/newsletter-form.js
+++ b/src/components/ui/forms/newsletter-form.js
@@ -1,0 +1,94 @@
+import { BodyText, H3 } from '@/ui/typography';
+
+import { Button } from '@/ui/buttons';
+import axios from 'axios';
+import { useRouter } from 'next/router';
+import { useState } from 'react';
+
+export const NewsletterForm = () => {
+  const router = useRouter();
+
+  const [submitSuccess, setSubmitSuccess] = useState(false);
+
+  // this handler should be further extended for a real project
+  const handleSubmit = e => {
+    // e.preventDefault();
+    // const submitURL = `/api/newsletter-form`;
+    // const formData = new FormData(e.target);
+    // if (formData) {
+    //   const data = {
+    //     email: formData.get('email'),
+    //     page: router.pathname,
+    //   };
+    //   axios
+    //     .post(submitURL, data)
+    //     .then(res => {
+    //       setSubmitSuccess(true);
+    //     })
+    //     .catch(err => {
+    //       console.error(err);
+    //       alert('There was an error submitting your form. Please try again.');
+    //     });
+    // }
+  };
+
+  return (
+    <>
+      <div className='text-center'>
+        <H3 className='font-bold text-white'>
+          {submitSuccess ? (
+            'Thank you for subscribing!'
+          ) : (
+            <span>Newsletter subscription form</span>
+          )}
+        </H3>
+        <BodyText className='mt-5 text-white'>
+          {submitSuccess
+            ? 'You will receive an email shortly with a link to confirm your subscription.'
+            : 'Receive the latest blog posts and news updates. No spam.'}
+        </BodyText>
+        <div className='mt-8'>
+          {!submitSuccess ? (
+            <form
+              className='flex flex-col items-center justify-center md:gap-4'
+              onSubmit={handleSubmit}>
+              <div className='flex flex-col w-full gap-4 md:flex-row md:justify-center'>
+                <input
+                  className={`w-full px-6 py-4 placeholder-black border rounded-md focus:border-cobalt border-gray' md:w-96`}
+                  name='email'
+                  type='email'
+                  placeholder='Email *'
+                  required
+                />
+                <Button
+                  label='Subscribe'
+                  type='button'
+                  variant='tertiary'
+                  className='px-10'
+                />
+              </div>
+
+              <div className='flex'>
+                <input
+                  id='newsletterCheckbox'
+                  type='checkbox'
+                  defaultValue
+                  className='focus:ring-2 focus:ring-transparent text-black w-4 h-4 p-2.5 bg-gray-50 rounded border border-gray-300'
+                  required
+                />
+
+                <label
+                  htmlFor='newsletterCheckbox'
+                  className='ml-2 text-left cursor-pointer'>
+                  <BodyText className='text-white'>
+                    I agree to receive email communications from ion8
+                  </BodyText>
+                </label>
+              </div>
+            </form>
+          ) : null}
+        </div>
+      </div>
+    </>
+  );
+};

--- a/src/components/ui/forms/two-step/index.js
+++ b/src/components/ui/forms/two-step/index.js
@@ -1,0 +1,131 @@
+// import * as Sentry from '@sentry/nextjs';
+import * as yup from 'yup';
+
+import { FormProvider, useForm } from 'react-hook-form';
+import { useContext, useState } from 'react';
+
+import { Step1 } from './step1';
+import { Step2 } from './step2';
+import axios from 'axios';
+import { useRouter } from 'next/router';
+import { yupResolver } from '@hookform/resolvers/yup';
+
+// adapted from https://github.com/orgs/react-hook-form/discussions/4028#discussioncomment-452478
+// conversionPath is always supplied by ContactBlock
+export const TwoStepForm = ({ conversionPath }) => {
+  // const { closeModalContact } = useContext(ModalContext); // defined in _app.js
+  const router = useRouter();
+
+  // What form step are we on? Count from 0 to index into the validation schema array.
+  const [activeStep, setActiveStep] = useState(0);
+
+  const defaultValues = {
+    firstName: '',
+    lastName: '',
+    aboutYourDepartment: '',
+    details: '',
+  };
+
+  const r = 'Please enter your ';
+  const validationSchema = [
+    // fields validation for form step 1
+    yup.object().shape({
+      firstName: yup.string().required(r + 'first name'),
+      lastName: yup.string().required(r + 'last name'),
+    }),
+    // fields validation for form step 2
+    yup.object().shape({
+      aboutYourDepartment: yup.string().required('Please select your department'),
+      details: yup.string().nullable(),
+    }),
+  ];
+  const currentValidationSchema = validationSchema[activeStep];
+
+  const {
+    handleSubmit,
+    trigger,
+    getValues,
+    register,
+    reset,
+    setValue,
+    formState: { errors },
+  } = useForm({
+    shouldUnregister: false,
+    defaultValues,
+    resolver: yupResolver(currentValidationSchema),
+    mode: 'onBlur',
+  });
+
+  function getStepContent(step) {
+    switch (step) {
+      case 0:
+        return (
+          <Step1
+            handleNext={handleNext}
+            register={register}
+            errors={errors}
+          />
+        );
+      case 1:
+        return (
+          <Step2
+            handleBack={handleBack}
+            register={register}
+            errors={errors}
+          />
+        );
+    }
+  }
+
+  const handleBack = () => {
+    setActiveStep(0);
+  };
+
+  const handleNext = () => {
+    trigger().then(isStepValid => {
+      if (isStepValid) setActiveStep(1);
+    });
+  };
+
+  // Submit the entire form - should not arrive here until validation passes for both pages
+  const ourHandleSubmit = formData => {
+    // for testing purposes and should be removed on a real project
+    console.log(formData);
+    // fake post URL - works around lack of CORS support on Zoho Forms
+    // see rewrite in next.config.js, and https://stackoverflow.com/a/65058898
+    /*
+    const postUrl = '/api/submit-contact-form';
+
+    let config = {
+      method: 'post',
+      url: postUrl,
+      data: formData,
+      headers: { 'Content-Type': 'multipart/form-data' },
+    };
+    axios(config)
+      .then(res => {
+        reset(); // Clear the form
+        router.push('/thank-you');
+      })
+      .catch(err => {
+        console.error('Error: ', err);
+        // Sentry.captureException(err);
+        alert('There was an error submitting your form. Please try again.');
+      })
+      .finally();
+      */
+  };
+
+  return (
+    <FormProvider>
+      <form
+        name='form'
+        onSubmit={handleSubmit(ourHandleSubmit)}
+        method='POST'
+        acceptCharset='UTF-8'
+        encType='multipart/form-data'>
+        {getStepContent(activeStep)}
+      </form>
+    </FormProvider>
+  );
+};

--- a/src/components/ui/forms/two-step/step1.js
+++ b/src/components/ui/forms/two-step/step1.js
@@ -20,7 +20,7 @@ export const Step1 = ({ handleNext, register, errors }) => {
           type='text'
           placeholder='First name'
           isRequired
-          register={{ ...register('firstName') }}
+          register={register}
           errorMessage={errors.firstName?.message}
         />
       </div>
@@ -32,7 +32,7 @@ export const Step1 = ({ handleNext, register, errors }) => {
           type='text'
           placeholder='Last name'
           isRequired
-          register={{ ...register('lastName') }}
+          register={register}
           errorMessage={errors.lastName?.message}
         />
       </div>

--- a/src/components/ui/forms/two-step/step1.js
+++ b/src/components/ui/forms/two-step/step1.js
@@ -1,0 +1,52 @@
+import { ButtonNoLink } from '@/ui/buttons';
+import { Input } from '@/ui/form-elements';
+
+/**
+ * @description - Form step 1
+ * @param {event} handleNext - the event that handles the next button
+ * @param {*} register - the React Hook Form register prop that applies the validation on the fields
+ * @param {string} errors - handles the error messages if any
+ * @returns
+ */
+export const Step1 = ({ handleNext, register, errors }) => {
+  return (
+    <div className='grid md:grid-cols-2 gap-4 mt-12'>
+      {' '}
+      {/* First name */}
+      <div>
+        <Input
+          label='First name'
+          name='firstName'
+          type='text'
+          placeholder='First name'
+          isRequired
+          register={{ ...register('firstName') }}
+          errorMessage={errors.firstName?.message}
+        />
+      </div>
+      {/* Last name */}
+      <div>
+        <Input
+          label='Last name'
+          name='lastName'
+          type='text'
+          placeholder='Last name'
+          isRequired
+          register={{ ...register('lastName') }}
+          errorMessage={errors.lastName?.message}
+        />
+      </div>
+      <div className='grid w-full md:col-start-2'>
+        <div className='place-self-end'>
+          <ButtonNoLink
+            className='m-auto mt-8 px-16 cursor-pointer'
+            label='Next >'
+            onClick={() => {
+              handleNext();
+            }}
+          />
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/ui/forms/two-step/step2.js
+++ b/src/components/ui/forms/two-step/step2.js
@@ -1,0 +1,56 @@
+import { Button, ButtonNoLink } from '@/ui/buttons';
+import { Select, Textarea } from '@/ui/form-elements';
+
+/**
+ * @description - Form step 2
+ * @param {event} handleBack - the event that handles the back button
+ * @param {*} register - the React Hook Form register prop that applies the validation on the fields
+ * @param {string} errors - handles the error messages if any
+ * @returns
+ */
+export const Step2 = ({ handleBack, register, errors }) => {
+  return (
+    <div className='grid gap-4 md:grid-cols-2 mt-12'>
+      {/* department dropdown */}
+      <div>
+        <Select
+          label='Tell us about your department'
+          name='aboutYourDepartment'
+          isRequired
+          options={['Software Engineering', 'Sales & Marketing', 'Design']}
+          register={{ ...register('aboutYourDepartment') }}
+          errorMessage={errors.aboutYourDepartment?.message}
+        />
+      </div>
+      {/* Anything else to say? */}
+      <div>
+        <Textarea
+          label='Your message'
+          name='details'
+          id='details'
+          register={{ ...register('details') }}
+        />
+      </div>
+
+      <div className='grid col-span-2'>
+        <div className='place-self-start col-start-1'>
+          <ButtonNoLink
+            className='m-auto mt-8 px-16 cursor-pointer'
+            label='< Back'
+            onClick={() => {
+              handleBack();
+            }}
+          />
+        </div>
+        <div className='col-start-2 place-self-end'>
+          <Button
+            className='m-auto px-16'
+            label='Submit'
+            type='button'
+            variant='primary'
+          />
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/ui/modals.js
+++ b/src/components/ui/modals.js
@@ -1,0 +1,108 @@
+import { BodyText, H3 } from '@/ui/typography';
+
+import { CloseIcon } from '@/svgs/icons';
+import { GeneralForm } from '@/forms/general-form';
+import Image from 'next/image';
+import { Modal } from 'flowbite-react';
+import { useRouter } from 'next/router';
+
+// WIP ImageModal is NOT ready for review yet.
+
+/**
+ * @description - this component uses the Flowbite-react Modal component in order to load the image in its original size
+ * @param {boolean} isModalOpen - state variable to determine whether the modal is open or close
+ * @param {*} setIsModalOpen - the state function that sets the state variable when the modal is either open or close
+ * @param {url} imgSrc - url of the image
+ * @param {number} imgOW - the original width of the image
+ * @param {number} imgOH - the original height of the image
+ * @param {string} imgAlt - the alt text
+ */
+export const ImageModal = ({
+  isModalOpen,
+  setIsModalOpen,
+  imgSrc,
+  imgOW,
+  imgOH,
+  imgAlt,
+}) => {
+  return (
+    <Modal
+      dismissible
+      show={isModalOpen}
+      onClose={() => setIsModalOpen(false)}
+      className='fixed left-0 right-0 z-50 w-full p-4 overflow-x-hidden overflow-y-auto bg-gray-900 top-20 bg-opacity-80 pt-28 md:pt-0 h-[100vh]'>
+      <div className='relative h-full mx-auto md:h-auto'>
+        <div className='relative shadow'>
+          {/* the modal close button */}
+          <button
+            type='button'
+            className='absolute z-10 top-4 right-5 bg-transparent p-1.5 ml-auto inline-flex items-center lg:-mr-[30%] md:-mr-[10%]'
+            data-modal-hide='popup-modal'
+            aria-label='Close'
+            onClick={() => setIsModalOpen(false)}>
+            <CloseIcon />
+            <span className='sr-only'>Close popup image</span>
+          </button>
+          <div className='grid grid-cols-1 text-center'>
+            <div className={`md:-ml-[30%] md:-mr-[30%] md:w-[${imgOW}px] relative`}>
+              {/* this the image loaded in its original width and height */}
+              <Image
+                src={imgSrc}
+                alt={imgAlt}
+                width={imgOW}
+                height={imgOH}
+                className='inline-block w-full'
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </Modal>
+  );
+};
+
+/**
+ * @description - FormModal component is used to load the form in a popup modal usually from the navigation button or a button in a section. This example here specifically loads the form in a modal when the contact button in the navigation bar is clicked.
+ * @param {string} pageTitle - used for page title tracking, could also be used for form title in some specific cases
+ * @returns
+ */
+
+export const FormModal = ({ pageTitle }) => {
+  const router = useRouter();
+  const handleRoute = () => {
+    // Preserve existing query parameters and remove showForm parameter
+    const newQuery = { ...router.query };
+    delete newQuery.showForm;
+    router.push({ pathname: router.pathname, query: newQuery }, undefined, {
+      shallow: true,
+    });
+  };
+  return (
+    <>
+      <div
+        className={`fixed inset-0 z-[1000] flex items-center justify-center overflow-x-hidden overflow-y-auto outline-none focus:outline-none bg-[#0a416bd9] p-6 md:p-0`}>
+        <div
+          id='contact-form-modal'
+          className='relative w-full border-deep-blue mx-auto mt-[400px] md:mt-0'>
+          <div className='relative bg-white md:w-[700px] p-6 rounded-[10px] shadow-lg mx-auto'>
+            {/* modal close button */}
+            <div className='flex justify-end w-full'>
+              <span
+                id='modal-close-btn'
+                className='cursor-pointer'
+                onClick={handleRoute}>
+                <CloseIcon />
+              </span>
+            </div>
+            <H3>Form in a modal</H3>
+            <BodyText>
+              Duis aute irure dolor in reprehenderit in voluptate velit esse cillum
+              dolore eu fugiat nulla pariatur.
+            </BodyText>
+            <GeneralForm pageTitle={pageTitle} />
+          </div>
+        </div>
+      </div>
+    </>
+  );
+};

--- a/src/components/ui/modals.js
+++ b/src/components/ui/modals.js
@@ -64,7 +64,7 @@ export const ImageModal = ({
 /**
  * @description - FormModal component is used to load the form in a popup modal usually from the navigation button or a button in a section. This example here specifically loads the form in a modal when the contact button in the navigation bar is clicked.
  * @param {string} pageTitle - used for page title tracking, could also be used for form title in some specific cases
- * @returns
+ * @returns {JSX.Element} - the form in a modal
  */
 
 export const FormModal = ({ pageTitle }) => {

--- a/src/components/ui/sliders.js
+++ b/src/components/ui/sliders.js
@@ -9,10 +9,9 @@ import React, { useRef, useState } from 'react';
 import { Swiper, SwiperSlide } from 'swiper/react';
 
 import { Button } from '@/ui/buttons';
-import { CloseIcon } from '@/svgs/icons';
 import Image from 'next/image';
+import { ImageModal } from '@/ui/modals';
 import Link from 'next/link';
-import { Modal } from 'flowbite-react';
 import { register } from 'swiper/element/bundle';
 
 register();
@@ -179,7 +178,6 @@ export const GallerySlider = () => {
 /**
  * @description - This component is a slider component for the testimonials displaying two testimonials per slide. This component uses a child component for each of the testimonials.
  * @param - The potential prop for a real world project could be the data file that would be passed on from the page to this component.
- * @returns
  */
 
 export const Testimonials = () => {
@@ -299,7 +297,7 @@ export const TestimonialCard = ({
 
 /**
  * @description - This component is a thumbnail gallery. When a thumbnail is clicked, the slider will slide to the related slide. Also when clicked on the enlarged image, a modal will pop up to further enlarge the image. The ThumbnailGallerySlider is developed to display the following information: Title, details and a list of images.
- * @param - the potential prop for this component is the data that would be passed to it from a data file under utils/
+ * @param - the potential prop for this component is the data that would be passed to it from a data file under utils/ - the data const consists of title, details and a list of images (src, alt, width, height)
  */
 export const ThumbnailGallerySlider = () => {
   const [thumbsSwiper, setThumbsSwiper] = useState(null);
@@ -453,62 +451,8 @@ export const ImageCanGoModal = ({ imgSrc, imgAlt, imgH, imgW }) => {
 };
 
 /**
- * @description - this component uses the Flowbite-react Modal component in order to load the image in its original size
- * @param {boolean} isModalOpen - state variable to determine whether the modal is open or close
- * @param {*} setIsModalOpen - the state function that sets the state variable when the modal is either open or close
- * @param {url} imgSrc - url of the image
- * @param {number} imgOW - the original width of the image
- * @param {number} imgOH - the original height of the image
- * @param {string} imgAlt - the alt text
- */
-export const ImageModal = ({
-  isModalOpen,
-  setIsModalOpen,
-  imgSrc,
-  imgOW,
-  imgOH,
-  imgAlt,
-}) => {
-  return (
-    <Modal
-      dismissible
-      show={isModalOpen}
-      onClose={() => setIsModalOpen(false)}
-      className='fixed left-0 right-0 z-50 w-full p-4 overflow-x-hidden overflow-y-auto bg-gray-900 top-20 bg-opacity-80 pt-28 md:pt-0 h-[100vh]'>
-      <div className='relative h-full mx-auto md:h-auto py-10'>
-        <div className='relative shadow'>
-          {/* the modal close button */}
-          <button
-            type='button'
-            className='absolute z-10 top-4 right-5 bg-transparent p-1.5 ml-auto inline-flex items-center lg:-mr-[30%] md:-mr-[10%]'
-            data-modal-hide='popup-modal'
-            aria-label='Close'
-            onClick={() => setIsModalOpen(false)}>
-            <CloseIcon />
-            <span className='sr-only'>Close popup image</span>
-          </button>
-          <div className='grid grid-cols-1 text-center'>
-            <div className={`md:-ml-[30%] md:-mr-[30%] md:w-[${imgOW}px] relative`}>
-              {/* this the image loaded in its original width and height */}
-              <Image
-                src={imgSrc}
-                alt={imgAlt}
-                width={imgOW}
-                height={imgOH}
-                className='inline-block w-full'
-              />
-            </div>
-          </div>
-        </div>
-      </div>
-    </Modal>
-);
-};
-
-
-/**
  * @description - This component displays a list of images that when clicked will control which slide should be displayed in the slider beneath it. The slider is a grid of two cols; image on the left and text information on the right.
- * @param - the potential prop can the data file
+ * @param - the potential prop can the data file in this order: imgSrc, imgAlt, imgW, imgH, title, desc, readMoreLink
  */
 
 export const ControlledSliderWImages = () => {
@@ -610,7 +554,7 @@ export const ControlledSliderWImages = () => {
 /**
  * @description - this component is a child component of the ControlledSliderWImages component. Lists a set of clickable images in a row. When one of the images is clicked, then the slider slides to the relevant index and displays the relevant information.
  * @param {state} controlledSwiper - the state variable that controls the index of the slide
- * @param {array} data - the information stored in data const
+ * @param {array} data - the information stored in data const in this order: imgSrc, imgAlt, imgW, imgH, title, desc, readMoreLink. In this particular component, we haven't used the title, desc and the readMoreLink.
  *
  */
 
@@ -636,6 +580,5 @@ const ClickableImages = ({ controlledSwiper, data }) => {
         </div>
       ))}
     </div>
-
   );
 };

--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -1,15 +1,31 @@
-import { useEffect } from 'react';
-import TagManager from 'react-gtm-module';
 import '../styles/main.scss';
 
+import { useEffect, useMemo, useState } from 'react';
+
+import { ContactFormContext } from '@/utils/context';
+import TagManager from 'react-gtm-module';
+
 const MyApp = ({ Component, pageProps }) => {
+  const [contactFormOpen, setContactFormOpen] = useState(false);
+  const providerContactFormOpen = useMemo(
+    () => ({
+      contactFormOpen,
+      setContactFormOpen,
+    }),
+    [contactFormOpen],
+  );
+
   useEffect(() => {
     if (process.env.NODE_ENV === 'production') {
       TagManager.initialize({ gtmId: process.env.NEXT_PUBLIC_GTM_ID });
     }
   }, []);
 
-  return <Component {...pageProps} />;
+  return (
+    <ContactFormContext.Provider value={providerContactFormOpen}>
+      <Component {...pageProps} />
+    </ContactFormContext.Provider>
+  );
 };
 
 export default MyApp;

--- a/src/pages/api/form-handler.js
+++ b/src/pages/api/form-handler.js
@@ -1,7 +1,11 @@
+/**
+ * this handler is a sample form handler that can be used and customized for real projects.
+ */
 import axios from 'axios';
 
-const contactHandler = async (req, res) => {
-  const webhookUrl = process.env.NEXT_PUBLIC_CONTACT_FORM_WEBHOOK;
+const formHandler = async (req, res) => {
+  const webhookUrl = '';
+  //const webhookUrl = process.env.NEXT_PUBLIC_CONTACT_FORM_WEBHOOK;
 
   const config = {
     method: req.method,
@@ -17,4 +21,4 @@ const contactHandler = async (req, res) => {
   }
 };
 
-export default contactHandler;
+export default formHandler;

--- a/src/pages/api/hello.js
+++ b/src/pages/api/hello.js
@@ -1,5 +1,0 @@
-// Next.js API route support: https://nextjs.org/docs/api-routes/introduction
-
-export default function handler(req, res) {
-  res.status(200).json({ name: 'Rishit Patel' });
-}

--- a/src/pages/components-gallery/index.js
+++ b/src/pages/components-gallery/index.js
@@ -7,7 +7,7 @@ import Layout from '@/components/layout';
 import { useRouter } from 'next/router';
 
 /**
- * @description - Requires a redesign. This page is going to be a gallery of all the components available in the Starter template. The structure is yet to be determined.
+ * @description - This page is going to be a gallery of all the components available in the Starter template. The structure is yet to be determined.
  */
 const ComponentsGallery = () => {
   const router = useRouter();

--- a/src/pages/components-gallery/index.js
+++ b/src/pages/components-gallery/index.js
@@ -1,13 +1,13 @@
 import { Container, SectionHeader } from '@/ui/containers';
 import { GallerySlider, Testimonials } from '@/ui/sliders';
 
-import { Form } from '@/ui/form';
+import { GeneralForm } from '@/components/ui/forms/general-form';
 import { H4 } from '@/ui/typography';
 import Layout from '@/components/layout';
 import { useRouter } from 'next/router';
 
 /**
- * @description - This page is going to be a gallery of all the components available in the Starter template. The structure is yet to be determined.
+ * @description - Requires a redesign. This page is going to be a gallery of all the components available in the Starter template. The structure is yet to be determined.
  */
 const ComponentsGallery = () => {
   const router = useRouter();
@@ -56,7 +56,7 @@ const ComponentsGallery = () => {
           <H4>Contact Form</H4>
           <hr class='h-px my-8 bg-gray-200 border-0 dark:bg-gray-700' />
         </div>
-        <Form conversionPageUrl={pageUrl} />
+        <GeneralForm conversionPageUrl={pageUrl} />
       </Container>
     </Layout>
   );

--- a/src/pages/components-gallery/list-of-forms.js
+++ b/src/pages/components-gallery/list-of-forms.js
@@ -1,0 +1,60 @@
+import {
+  Container,
+  FullWidthContainer,
+  SectionHeader,
+} from '@/components/ui/containers';
+
+import { FormWConditionalFields } from '@/components/ui/forms/form-with-conditional-fields';
+import { GeneralForm } from '@/components/ui/forms/general-form';
+import Layout from '@/components/layout';
+import { NewsletterForm } from '@/components/ui/forms/newsletter-form';
+import { TwoStepForm } from '@/components/ui/forms/two-step';
+
+/** This page will list different variants of forms (simple contact form, two-step form, modal form and newsletter.). */
+const ListOfForms = () => {
+  return (
+    <Layout seoTitle='List of Forms'>
+      {/* The general form */}
+      <FullWidthContainer>
+        <Container>
+          <SectionHeader
+            title='General form'
+            subTitle='A simple generic form with optional and required fields.'
+          />
+          <GeneralForm />
+        </Container>
+      </FullWidthContainer>
+
+      {/* The form with conditional fields */}
+      <FullWidthContainer className='bg-light-blue'>
+        <Container>
+          <SectionHeader
+            title='Form with conditional fields'
+            subTitle='Select "Software Engineering" from the select field and you will see a conditional field being added beside it. Also the radio buttons display conditional text based upon which one is being selected. Cool right?'
+          />
+          <FormWConditionalFields />
+        </Container>
+      </FullWidthContainer>
+
+      {/* The two-step form */}
+      <FullWidthContainer>
+        <Container>
+          <SectionHeader
+            title='The two-step form'
+            subTitle='Fill in the fields (required and/or optional ones) in both steps and go back and forth between the steps to see the valus perserve between the steps.'
+          />
+          <TwoStepForm />
+        </Container>
+      </FullWidthContainer>
+
+      {/* The newsletter form */}
+      <FullWidthContainer className='bg-cobalt'>
+        <Container>
+          <NewsletterForm />
+        </Container>
+      </FullWidthContainer>
+    </Layout>
+  );
+};
+
+export default ListOfForms;

--- a/src/pages/components-gallery/list-of-forms.js
+++ b/src/pages/components-gallery/list-of-forms.js
@@ -60,8 +60,9 @@ const ListOfForms = () => {
   ];
   return (
     <Layout seoTitle='List of Forms'>
+      {/* Should be removed once the dynamic form is approved */}
       {/* The general form */}
-      <FullWidthContainer>
+      {/* <FullWidthContainer>
         <Container>
           <SectionHeader
             title='General form'
@@ -69,59 +70,16 @@ const ListOfForms = () => {
           />
           <GeneralForm />
         </Container>
-      </FullWidthContainer>
+      </FullWidthContainer> */}
 
-      {/* The general form */}
+      {/* The form with dynamic fields */}
       <FullWidthContainer>
         <Container>
           <SectionHeader
             title='Form with Dynamic Fields'
             subTitle='A simple generic form with optional and required fields.'
           />
-          {/* <FormWDynamicFields
-            // suggestion: fields component
-            // jsx object
-
-            fields={[
-              ['first name', 'text', 'isRequired', 'Enter your first name'],
-              ['phone number', 'tel', '', ''],
-              ['email address', 'email', 'isRequired', 'Enter your email address'],
-              [
-                'department',
-                'select',
-                'isRequired',
-                'Choose one of the options',
-                ['Software Engineering', 'Sales & Marketing', 'Design'],
-              ],
-            ]}> */}
           <FormWDynamicFields fields={dynamicFields} />
-
-          {/* couldn't get to work, plus the having the fields details defined in a const seems cleaner */}
-          {/* <Field
-              label='First name'
-              type='text'
-              required={true}
-              validationMessage='Enter your first name'
-            />
-            <Field
-              label='Phone number'
-              type='tel'
-              required={false}
-              validationMessage='Enter your phone number'
-            />
-            <Field
-              label='Email address'
-              type='email'
-              required={true}
-              validationMessage='Enter your email address'
-            />
-            <Field
-              label='Your department'
-              type='select'
-              required={false}
-              validationMessage='Choose an option'
-              options={['Software Engineering', 'Sales & Marketing', 'Design']}
-            /> */}
         </Container>
       </FullWidthContainer>
 

--- a/src/pages/components-gallery/list-of-forms.js
+++ b/src/pages/components-gallery/list-of-forms.js
@@ -3,6 +3,10 @@ import {
   FullWidthContainer,
   SectionHeader,
 } from '@/components/ui/containers';
+import {
+  Field,
+  FormWDynamicFields,
+} from '@/components/ui/forms/form-with-dynamic-fields';
 
 import { FormWConditionalFields } from '@/components/ui/forms/form-with-conditional-fields';
 import { GeneralForm } from '@/components/ui/forms/general-form';
@@ -12,6 +16,48 @@ import { TwoStepForm } from '@/components/ui/forms/two-step';
 
 /** This page will list different variants of forms (simple contact form, two-step form, modal form and newsletter.). */
 const ListOfForms = () => {
+  const dynamicFields = [
+    {
+      type: 'text',
+      label: 'First Name',
+      name: 'firstName',
+      required: true,
+      className: '',
+      validationMsg: 'Enter your first name',
+    },
+    {
+      type: 'text',
+      label: 'Last Name',
+      name: 'lastName',
+      required: true,
+      className: '',
+      validationMsg: 'Enter your last name',
+    },
+    {
+      type: 'tel',
+      label: 'Phone Number',
+      name: 'phoneNumber',
+      required: false,
+      className: '',
+    },
+    {
+      type: 'email',
+      label: 'Email Address',
+      name: 'emailAddress',
+      required: true,
+      className: '',
+      validationMsg: 'Enter your email address',
+    },
+    {
+      type: 'select',
+      label: 'Select your department',
+      name: 'yourDepartment',
+      required: true,
+      options: ['Software Engineering', 'Sales & Marketing', 'Design'],
+      className: '',
+      validationMsg: 'Select your department',
+    },
+  ];
   return (
     <Layout seoTitle='List of Forms'>
       {/* The general form */}
@@ -22,6 +68,60 @@ const ListOfForms = () => {
             subTitle='A simple generic form with optional and required fields.'
           />
           <GeneralForm />
+        </Container>
+      </FullWidthContainer>
+
+      {/* The general form */}
+      <FullWidthContainer>
+        <Container>
+          <SectionHeader
+            title='Form with Dynamic Fields'
+            subTitle='A simple generic form with optional and required fields.'
+          />
+          {/* <FormWDynamicFields
+            // suggestion: fields component
+            // jsx object
+
+            fields={[
+              ['first name', 'text', 'isRequired', 'Enter your first name'],
+              ['phone number', 'tel', '', ''],
+              ['email address', 'email', 'isRequired', 'Enter your email address'],
+              [
+                'department',
+                'select',
+                'isRequired',
+                'Choose one of the options',
+                ['Software Engineering', 'Sales & Marketing', 'Design'],
+              ],
+            ]}> */}
+          <FormWDynamicFields fields={dynamicFields} />
+
+          {/* couldn't get to work, plus the having the fields details defined in a const seems cleaner */}
+          {/* <Field
+              label='First name'
+              type='text'
+              required={true}
+              validationMessage='Enter your first name'
+            />
+            <Field
+              label='Phone number'
+              type='tel'
+              required={false}
+              validationMessage='Enter your phone number'
+            />
+            <Field
+              label='Email address'
+              type='email'
+              required={true}
+              validationMessage='Enter your email address'
+            />
+            <Field
+              label='Your department'
+              type='select'
+              required={false}
+              validationMessage='Choose an option'
+              options={['Software Engineering', 'Sales & Marketing', 'Design']}
+            /> */}
         </Container>
       </FullWidthContainer>
 

--- a/src/pages/thank-you/index.js
+++ b/src/pages/thank-you/index.js
@@ -1,0 +1,34 @@
+import { Container, SectionHeader } from '@/components/ui/containers';
+import { H1, LgText } from '@/components/ui/typography';
+
+import { Button } from '@/components/ui/buttons';
+import Layout from '@/components/layout';
+
+const ThankYou = () => {
+  var title = 'Thank You';
+
+  return (
+    <Layout
+      seoTitle={title}
+      seoDesc=''>
+      <div className='items-center w-full mx-auto text-center bg-white py-14 md:px-12 lg:px-40'>
+        <Container className='py-24'>
+          <div className='xl:px-28'>
+            <H1 className='pb-7'>Thank you!</H1>
+            <LgText className='text-gray-500 pb-7'>
+              Your information has been received.
+            </LgText>
+            <Button
+              link='/'
+              label='Go to home page'
+              className='w-[245px] mx-auto'
+              type='link'
+            />
+          </div>
+        </Container>
+      </div>
+    </Layout>
+  );
+};
+
+export default ThankYou;

--- a/src/utils/context.js
+++ b/src/utils/context.js
@@ -1,0 +1,3 @@
+import { createContext } from 'react';
+
+export const ContactFormContext = createContext();

--- a/src/utils/data/data_01.js
+++ b/src/utils/data/data_01.js
@@ -1,0 +1,1 @@
+// this file is a sample file for data files

--- a/src/utils/data/data_01.js
+++ b/src/utils/data/data_01.js
@@ -1,1 +1,1 @@
-// this file is a sample file for data files
+// Use this file to store copy or content of the components. This will help organize and separate the data from the code.

--- a/yarn.lock
+++ b/yarn.lock
@@ -771,6 +771,11 @@
   dependencies:
     "@hapi/hoek" "^9.0.0"
 
+"@hookform/error-message@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@hookform/error-message/-/error-message-2.0.1.tgz#6a37419106e13664ad6a29c9dae699ae6cd276b8"
+  integrity sha512-U410sAr92xgxT1idlu9WWOVjndxLdgPUHEB8Schr27C9eh7/xUnITWpCMF93s+lGiG++D4JnbSnrb5A21AdSNg==
+
 "@hookform/resolvers@^3.3.2":
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/@hookform/resolvers/-/resolvers-3.3.2.tgz#5c40f06fe8137390b071d961c66d27ee8f76f3bc"


### PR DESCRIPTION
This PR brings in various forms from past projects into one - lots of refactoring and customization in order to make the forms consistent and compatible with the new versions of the packages like React Hook Form and the Yup validation, Flowbite etc..

The forms and functionalities that have been added in this PR are:

1. A generic form having the common fields (required and optional)
2. Form with conditional fields
3. Two step form
4. Newsletter
5. and the generic form being loaded in a modal (navigation button)

I have either commented out the form submission codes from each form, or have commented them out since the form submission requirement could be specific for a real project and can be implemented out of Starter template's scope.

[Preview link](https://nextjs-starter-git-seema-form-update-ion8-fedev.vercel.app/components-gallery/list-of-forms)